### PR TITLE
Add Flask API and helper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# MTHFR Support Reports
+
+This repository contains utilities for building MTHFR Support PDF reports. It includes
+helper functions for assembling report data and a small Flask API that exposes
+endpoints for generating the PDFs.
+
+## Requirements
+
+Install dependencies using pip:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the API
+
+Start the server by executing `main.py`:
+
+```bash
+python main.py
+```
+
+The application listens on port `8000` by default.
+
+## Endpoints
+
+### `POST /report/variant`
+Generate the standard variant report. The request body should be JSON with a
+`genotypes` list containing objects with at least `rsid` and `genotype` keys.
+Optional keys `file_name` and `folder_name` can be provided to customize the
+resulting PDF headers.
+
+### `POST /report/methylation`
+Create a methylation report using the same payload format as `/report/variant`.
+
+### `POST /report/covid`
+Create the COVID‑19 report. The payload format matches the previous endpoints.
+
+All endpoints return the generated PDF as an attachment. If an error occurs a
+JSON response with an `error` key is returned instead.
+
+## Generating Reports Manually
+
+The `compute.py` module exposes helper functions that can be used without the
+API. For example:
+
+```python
+import pandas as pd
+import compute
+
+# dataframe with columns 'rsid' and 'genotype'
+df = pd.DataFrame([...])
+result = compute.create_dataframe(df)
+report_bytes = compute.generate_pdf(result, "My Report", "folder")
+```
+
+The output bytes can then be written to a file.

--- a/compute.py
+++ b/compute.py
@@ -15,7 +15,12 @@ from reportlab.lib.utils import ImageReader
 from reportlab.pdfgen import canvas
 from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
 from reportlab.lib.units import inch
-from helper import check_result, get_result_color, create_primary_snps, create_secondary_snps
+from constants.helper import (
+    check_result,
+    get_result_color,
+    create_primary_snps,
+    create_secondary_snps,
+)
 from reportlab.lib.enums import TA_CENTER, TA_LEFT
 from constants.constants import primary_genes, secondary_genes, gene_references
 from io import BytesIO

--- a/constants/helper.py
+++ b/constants/helper.py
@@ -18,3 +18,76 @@ def create_link_text(url, text):
     :return: A string containing the HTML <a> tag.
     """
     return f'<a href="{url}" color="blue"><u>{text}</u></a>'
+
+
+def check_result(row):
+    """Return a result string based on genotype and risk allele."""
+    genotype = str(row.get("genotype", "")).upper()
+    risk = str(row.get("Risk", "")).upper()
+    if not genotype or not risk:
+        return ""
+    risk_alleles = list(risk)
+    matches = sum(1 for a in genotype if a in risk_alleles)
+    if matches == 2:
+        return "+/+"
+    if matches == 1:
+        return "+/-"
+    return "-/-"
+
+
+def get_result_color(result):
+    """Map a result string to a table background colour."""
+    mapping = {
+        "+/+": "#FC787F",  # red
+        "+/-": "#FBFBC0",  # yellow
+        "-/-": "#75B776",  # green
+    }
+    return mapping.get(result.strip(), "white")
+
+
+def create_primary_snps(story, header, points, studies):
+    """Append primary SNP information to the story list."""
+    from reportlab.lib.enums import TA_LEFT
+    from reportlab.platypus import Paragraph, Spacer, ListFlowable, ListItem
+    from reportlab.lib.styles import getSampleStyleSheet, ListStyle
+
+    styles = getSampleStyleSheet()
+    header_style = styles["Heading2"]
+    header_style.fontName = "Times-Bold"
+    header_style.alignment = TA_LEFT
+    story.append(Paragraph(header, header_style))
+
+    bullet_style = ListStyle("bullet")
+    items = []
+    for item in points:
+        items.append(ListItem(Paragraph(item.get("point", ""), styles["Normal"])) )
+        for sub in item.get("subpoint", []):
+            items.append(ListItem(Paragraph(sub, styles["Normal"]), level=1))
+    story.append(ListFlowable(items, bulletType="bullet", style=bullet_style))
+
+    if studies:
+        story.append(Paragraph("Associated Studies", header_style))
+        study_items = [ListItem(Paragraph(s, styles["Normal"])) for s in studies]
+        story.append(ListFlowable(study_items, bulletType="bullet", style=bullet_style))
+
+    story.append(Spacer(1, 12))
+    return story
+
+
+def create_secondary_snps(story, header, paragraphs):
+    """Append secondary SNP text to the story list."""
+    from reportlab.lib.enums import TA_LEFT
+    from reportlab.platypus import Paragraph, Spacer
+    from reportlab.lib.styles import getSampleStyleSheet
+
+    styles = getSampleStyleSheet()
+    header_style = styles["Heading2"]
+    header_style.fontName = "Times-Bold"
+    header_style.alignment = TA_LEFT
+    story.append(Paragraph(header, header_style))
+
+    for p in paragraphs:
+        story.append(Paragraph(p, styles["Normal"]))
+        story.append(Spacer(1, 12))
+
+    return story

--- a/main.py
+++ b/main.py
@@ -1,0 +1,59 @@
+import pandas as pd
+from io import BytesIO
+from flask import Flask, request, send_file, jsonify
+import compute
+
+app = Flask(__name__)
+
+
+def _parse_genotypes(data):
+    """Convert incoming JSON data to DataFrame."""
+    if not isinstance(data, list):
+        raise ValueError("'genotypes' must be a list of objects")
+    return pd.DataFrame(data)
+
+
+@app.route("/report/variant", methods=["POST"])
+def variant_report():
+    try:
+        body = request.get_json(force=True)
+        df = _parse_genotypes(body.get("genotypes", []))
+        file_name = body.get("file_name", "Variant Report")
+        folder_name = body.get("folder_name", "")
+        dataf = compute.create_dataframe(df)
+        pdf_bytes = compute.generate_pdf(dataf, file_name, folder_name)
+        return send_file(BytesIO(pdf_bytes), mimetype="application/pdf", as_attachment=True, download_name="variant_report.pdf")
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 400
+
+
+@app.route("/report/methylation", methods=["POST"])
+def methylation_report():
+    try:
+        body = request.get_json(force=True)
+        df = _parse_genotypes(body.get("genotypes", []))
+        file_name = body.get("file_name", "Methylation Report")
+        folder_name = body.get("folder_name", "")
+        dataf = compute.create_meth_dataframe(df)
+        pdf_bytes = compute.generate_pdf(dataf, file_name, folder_name)
+        return send_file(BytesIO(pdf_bytes), mimetype="application/pdf", as_attachment=True, download_name="methylation_report.pdf")
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 400
+
+
+@app.route("/report/covid", methods=["POST"])
+def covid_report():
+    try:
+        body = request.get_json(force=True)
+        df = _parse_genotypes(body.get("genotypes", []))
+        file_name = body.get("file_name", "Covid Report")
+        folder_name = body.get("folder_name", "")
+        dataf = compute.create_covid_dataframe(df)
+        pdf_bytes = compute.generate_covid_pdf(dataf, file_name, folder_name)
+        return send_file(BytesIO(pdf_bytes), mimetype="application/pdf", as_attachment=True, download_name="covid_report.pdf")
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 400
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+pandas
+openpyxl
+reportlab


### PR DESCRIPTION
## Summary
- add simple Flask API with endpoints for PDF report generation
- implement missing helper functions and fix imports
- document API usage in README
- add dependency requirements

## Testing
- `python -m py_compile compute.py main.py constants/helper.py`
- `python main.py` *(fails: ModuleNotFoundError)*
- `pip install -r requirements.txt`
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_b_6884b73a4b8c832188b9842664c2c4b7