### PR TITLE
Update README with curl example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ python main.py
 
 The application listens on port `8000` by default.
 
+## Testing with `curl`
+
+After starting the server you can verify an endpoint with a simple `curl` request.
+For example, to generate a variant report run:
+
+```bash
+curl -X POST http://localhost:8000/report/variant \
+     -H "Content-Type: application/json" \
+     -d '{"genotypes": [{"rsid": "rs123", "genotype": "AA"}]}' \
+     --output variant_report.pdf
+```
+
+This saves the generated PDF to `variant_report.pdf`.
+
 ## Endpoints
 
 ### `POST /report/variant`


### PR DESCRIPTION
## Summary
- document how to test the API with `curl`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile *.py`
- `python main.py` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_b_6884b979253c8321be3bb5fd5acdeac8