### PR TITLE
Add file output option for report endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,17 @@ The application listens on port `8000` by default.
 Generate the standard variant report. The request body should be JSON with a
 `genotypes` list containing objects with at least `rsid` and `genotype` keys.
 Optional keys `file_name` and `folder_name` can be provided to customize the
-resulting PDF headers.
+resulting PDF headers.  A body key `output` can be set to `"file"` to save the
+resulting PDF under the repository `tmp/` directory instead of streaming the
+binary back in the response.
 
 ### `POST /report/methylation`
 Create a methylation report using the same payload format as `/report/variant`.
+The optional `output` field behaves the same as the variant endpoint.
 
 ### `POST /report/covid`
-Create the COVID‑19 report. The payload format matches the previous endpoints.
+Create the COVID‑19 report. The payload format matches the previous endpoints
+and also accepts the `output` field.
 
 All endpoints return the generated PDF as an attachment. If an error occurs a
 JSON response with an `error` key is returned instead.
@@ -52,6 +56,10 @@ import compute
 df = pd.DataFrame([...])
 result = compute.create_dataframe(df)
 report_bytes = compute.generate_pdf(result, "My Report", "folder")
+
+# or save directly to a file
+compute.generate_pdf(result, "My Report", "folder", output_path="tmp/my.pdf")
 ```
 
-The output bytes can then be written to a file.
+The output bytes can then be written to a file or specify ``output_path`` to let
+the function handle saving.

--- a/compute.py
+++ b/compute.py
@@ -56,7 +56,24 @@ figure_numbers = {
 }
 
 
-def generate_pdf(content, file_name, folder_name, font_size=11):
+def generate_pdf(content, file_name, folder_name, font_size=11, output_path=None):
+    """Generate the standard PDF report.
+
+    Parameters
+    ----------
+    content : pandas.DataFrame
+        DataFrame containing the SNP data that should appear in the report.
+    file_name : str
+        Title for the PDF document.
+    folder_name : str
+        Optional subtitle that appears under the title.
+    font_size : int, default 11
+        Base font size used for tables.
+    output_path : str or None, optional
+        When provided the resulting PDF is also written to this path and the
+        function returns that path instead of the raw bytes.
+    """
+
     pdf_output = BytesIO()
 
     class bookmark_flowable(Flowable):
@@ -383,7 +400,12 @@ def generate_pdf(content, file_name, folder_name, font_size=11):
     )
     pdf_data = pdf_output.getvalue()
     pdf_output.close()
-    
+
+    if output_path:
+        with open(output_path, "wb") as fh:
+            fh.write(pdf_data)
+        return output_path
+
     return pdf_data
 
 
@@ -556,7 +578,13 @@ def create_covid_dataframe(df):
 
 
 
-def generate_covid_pdf(content, file_name, folder_name, font_size=11):
+def generate_covid_pdf(content, file_name, folder_name, font_size=11, output_path=None):
+    """Generate the COVID report PDF.
+
+    Parameters mirror :func:`generate_pdf` with the additional ability to write
+    the generated PDF to ``output_path`` when supplied.
+    """
+
     pdf_output = BytesIO()
     
     class bookmark_flowable(Flowable):
@@ -914,5 +942,10 @@ def generate_covid_pdf(content, file_name, folder_name, font_size=11):
     doc.build(story, canvasmaker=HeaderFooterCanvas)
     pdf_data = pdf_output.getvalue()
     pdf_output.close()
-    
+
+    if output_path:
+        with open(output_path, "wb") as fh:
+            fh.write(pdf_data)
+        return output_path
+
     return pdf_data

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import pandas as pd
 from io import BytesIO
 from flask import Flask, request, send_file, jsonify
 import compute
+import uuid
 
 app = Flask(__name__)
 
@@ -20,7 +21,12 @@ def variant_report():
         df = _parse_genotypes(body.get("genotypes", []))
         file_name = body.get("file_name", "Variant Report")
         folder_name = body.get("folder_name", "")
+        output_type = body.get("output", "binary")
         dataf = compute.create_dataframe(df)
+        if output_type == "file":
+            path = f"tmp/{uuid.uuid4().hex}.pdf"
+            compute.generate_pdf(dataf, file_name, folder_name, output_path=path)
+            return jsonify({"file_path": path})
         pdf_bytes = compute.generate_pdf(dataf, file_name, folder_name)
         return send_file(BytesIO(pdf_bytes), mimetype="application/pdf", as_attachment=True, download_name="variant_report.pdf")
     except Exception as exc:
@@ -34,7 +40,12 @@ def methylation_report():
         df = _parse_genotypes(body.get("genotypes", []))
         file_name = body.get("file_name", "Methylation Report")
         folder_name = body.get("folder_name", "")
+        output_type = body.get("output", "binary")
         dataf = compute.create_meth_dataframe(df)
+        if output_type == "file":
+            path = f"tmp/{uuid.uuid4().hex}.pdf"
+            compute.generate_pdf(dataf, file_name, folder_name, output_path=path)
+            return jsonify({"file_path": path})
         pdf_bytes = compute.generate_pdf(dataf, file_name, folder_name)
         return send_file(BytesIO(pdf_bytes), mimetype="application/pdf", as_attachment=True, download_name="methylation_report.pdf")
     except Exception as exc:
@@ -48,7 +59,12 @@ def covid_report():
         df = _parse_genotypes(body.get("genotypes", []))
         file_name = body.get("file_name", "Covid Report")
         folder_name = body.get("folder_name", "")
+        output_type = body.get("output", "binary")
         dataf = compute.create_covid_dataframe(df)
+        if output_type == "file":
+            path = f"tmp/{uuid.uuid4().hex}.pdf"
+            compute.generate_covid_pdf(dataf, file_name, folder_name, output_path=path)
+            return jsonify({"file_path": path})
         pdf_bytes = compute.generate_covid_pdf(dataf, file_name, folder_name)
         return send_file(BytesIO(pdf_bytes), mimetype="application/pdf", as_attachment=True, download_name="covid_report.pdf")
     except Exception as exc:


### PR DESCRIPTION
## Summary
- support optional file saving in `generate_pdf` and `generate_covid_pdf`
- allow API clients to request file saving using `output` parameter
- document new behaviour in README

## Testing
- `python -m py_compile main.py compute.py helper.py constants/constants.py constants/helper.py`

------
https://chatgpt.com/codex/tasks/task_b_68876f66544c832181076fcc350b6a2f